### PR TITLE
patch: fix to stage create-release-branch

### DIFF
--- a/.github/workflows/branch-name-checks.yml
+++ b/.github/workflows/branch-name-checks.yml
@@ -20,10 +20,10 @@ jobs:
             $BRANCH_NAME = $env:BRANCH_NAME -replace 'refs/heads/', ''
             Write-Output "Checking branch name $BRANCH_NAME"
 
-            if ($BRANCH_NAME -notmatch '^(feature|release|bugfix|hotfix)/') 
+            if ($BRANCH_NAME -notmatch '^(feature|release|bugfix|hotfix|fix)/') 
             {
               Write-Output "Branch $BRANCH_NAME does not follow the required naming convention!"
-              Write-Output "Branch name must start with feature/, release/, bugfix/, or hotfix/"
+              Write-Output "Branch name must start with feature/, release/, bugfix/, hotfix/ or fix/"
               Write-Output "Fix the branch name before creating a PR to avoid rejection"
               exit 1
             }

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -176,13 +176,14 @@ jobs:
           $BRANCH_NAME = "release/$env:PackageId-v$env:Version"
 
           git fetch origin
-          $branchExists = git show-ref --quiet "refs/heads/$BRANCH_NAME"
+          git show-ref --quiet "refs/heads/$BRANCH_NAME"
+          $branchExists = $LASTEXITCODE -eq 0
 
           if ($branchExists) 
           {
             Write-Host "Branch $BRANCH_NAME already exists."
             exit 0
           }
-
           git checkout -b $BRANCH_NAME
           git push origin $BRANCH_NAME
+          

--- a/SBOM2GlobalIdentifier/ProductTokenAnalyzer.cs
+++ b/SBOM2GlobalIdentifier/ProductTokenAnalyzer.cs
@@ -13,7 +13,7 @@ namespace Tecan.Tools.Sbom2GlobalIdentifier
         private const int ASSEMBLY_VERSION_IDX = 5;         // index of assembly version in the string sent in cpeName
         private const int EXPECTED_ELEMENT_LENGTH = 6;
 
-        //private const int MAX_ENTRY_COUNT = 5;
+        private const int MAX_ENTRY_COUNT = 5;
 
         private const string CPE_ELEMENT = "cpe";
         private const string CPE_NAME_ELEMENT = "cpeName";
@@ -111,7 +111,7 @@ namespace Tecan.Tools.Sbom2GlobalIdentifier
             }
             else
             {
-                if( !_hasNoMatchFoundBeenProcessedOnce )
+                if( !_hasNoMatchFoundBeenProcessedOnce)
                 {
                     CpeExplorer.NoMatchFoundInResponse( assemblyName );
                 }
@@ -141,11 +141,11 @@ namespace Tecan.Tools.Sbom2GlobalIdentifier
             }
             ConsoleOutput.WriteToConsole( $"{string.Join( ":", cpeElements )}", ConsoleColor.Yellow );
 
-            //if( _potentialEntryCount < MAX_ENTRY_COUNT )
-            //{
-            FileManipulator.AddToContainer( assemblyName, $"{CpeExplorer.CpePrefix} {string.Join( ":", cpeElements )}" );
-            _potentialEntryCount++;
-            //}
+            if( _potentialEntryCount < MAX_ENTRY_COUNT )
+            {
+                FileManipulator.AddToContainer( assemblyName, $"{CpeExplorer.CpePrefix} {string.Join( ":", cpeElements )}" );
+                _potentialEntryCount++;
+            }
         }
     }
 }

--- a/SBOM2GlobalIdentifier/ProductTokenAnalyzer.cs
+++ b/SBOM2GlobalIdentifier/ProductTokenAnalyzer.cs
@@ -13,7 +13,7 @@ namespace Tecan.Tools.Sbom2GlobalIdentifier
         private const int ASSEMBLY_VERSION_IDX = 5;         // index of assembly version in the string sent in cpeName
         private const int EXPECTED_ELEMENT_LENGTH = 6;
 
-        private const int MAX_ENTRY_COUNT = 5;
+        //private const int MAX_ENTRY_COUNT = 5;
 
         private const string CPE_ELEMENT = "cpe";
         private const string CPE_NAME_ELEMENT = "cpeName";
@@ -111,7 +111,7 @@ namespace Tecan.Tools.Sbom2GlobalIdentifier
             }
             else
             {
-                if( !_hasNoMatchFoundBeenProcessedOnce)
+                if( !_hasNoMatchFoundBeenProcessedOnce )
                 {
                     CpeExplorer.NoMatchFoundInResponse( assemblyName );
                 }
@@ -141,11 +141,11 @@ namespace Tecan.Tools.Sbom2GlobalIdentifier
             }
             ConsoleOutput.WriteToConsole( $"{string.Join( ":", cpeElements )}", ConsoleColor.Yellow );
 
-            if( _potentialEntryCount < MAX_ENTRY_COUNT )
-            {
-                FileManipulator.AddToContainer( assemblyName, $"{CpeExplorer.CpePrefix} {string.Join( ":", cpeElements )}" );
-                _potentialEntryCount++;
-            }
+            //if( _potentialEntryCount < MAX_ENTRY_COUNT )
+            //{
+            FileManipulator.AddToContainer( assemblyName, $"{CpeExplorer.CpePrefix} {string.Join( ":", cpeElements )}" );
+            _potentialEntryCount++;
+            //}
         }
     }
 }


### PR DESCRIPTION
Fixed a logic error in create-release-branch.
Added logic `$branchExists = $LASTEXITCODE -eq 0` to capture the last exit code. This way we can use $branchExists properly in the following code.
